### PR TITLE
project: hide errors when not inside a git repo

### DIFF
--- a/jobrunner_git/project.py
+++ b/jobrunner_git/project.py
@@ -1,5 +1,5 @@
 import logging
-from subprocess import CalledProcessError, check_output
+from subprocess import DEVNULL, CalledProcessError, check_output
 from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 def run(*args: str) -> Optional[str]:
     try:
-        return check_output(args, encoding="utf-8").strip()
+        return check_output(args, encoding="utf-8", stderr=DEVNULL).strip()
     except CalledProcessError as err:
         logger.warning("error: %s", err)
         return None
@@ -16,7 +16,9 @@ def run(*args: str) -> Optional[str]:
 def workspaceProject() -> Tuple[str, bool]:
     head = run("git", "rev-parse", "HEAD")
     if not head:
-        return "", False
+        raise NotImplementedError
 
     top = run("git", "rev-parse", "--show-toplevel")
-    return f"{top}:{head}" if top else head, True
+    status = run("git", "status", "-s", "--porcelain")
+    dirty = "*" if status else ""
+    return f"{top}:{head}{dirty}" if top else head, True


### PR DESCRIPTION
If the current directory is not contained within any git repo, we don't want to see any error output when starting jobs.

Use the new plugin protocol and raise NotImplementedError in this case (jobrunner v2.5.0).